### PR TITLE
ci: :construction_worker: optimize github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,46 +8,21 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.11
 
     - name: Install dependencies
-      run: pip install black isort flake8
+      run: pip install .
 
-    - name: Install pre-commit
-      run: pip install pre-commit
+    - name: Install pytest
+      run: pip install pytest
 
-    - name: Run pre-commit hooks
-      run: pre-commit run --all-files
+    - name: Build Docker Compose
+      run: make build
 
-  build-docker:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Build Docker Compose
-        run: make build
-
-  unit-tests:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.11
-
-      - name: Install dependencies
-        run: make install
-
-      - name: Run Unit Tests
-        run: make test
+    - name: Run Unit Tests
+      run: pytest -vx --cov=app --cov-report term-missing --cov-fail-under=95


### PR DESCRIPTION
You don't need to install pre-commit you should use "https://pre-commit.ci/" which I already setup in other PR once you setup formatter will work faster and work as a separate PR 